### PR TITLE
Print more info when walking the input tree.

### DIFF
--- a/poole.py
+++ b/poole.py
@@ -497,7 +497,7 @@ def build(project, opts):
         cwd_site = cwd[len(dir_in):].lstrip(os.path.sep)
         for d in dirs[:]:
             src = opj(cwd_site, d)
-            if re.search(opts.ignore, src):
+            if re.search(opts.ignore, d):
                 print('info   : ignoring dir %s' % src)
                 dirs.remove(d)
             else:


### PR DESCRIPTION
I renamed variables for better readability (in my opinion), and added messages when:
- creating a directory
- ignoring a directory
- ignoring a file

In the second commit I change the ignore test from for example `./input/name` to `name`.
